### PR TITLE
Update to GNOME runtime version 40

### DIFF
--- a/org.soundconverter.SoundConverter.yml
+++ b/org.soundconverter.SoundConverter.yml
@@ -1,6 +1,6 @@
 app-id: org.soundconverter.SoundConverter
 runtime: org.gnome.Platform
-runtime-version: '3.38'
+runtime-version: '40'
 sdk: org.gnome.Sdk
 rename-appdata-file: soundconverter.appdata.xml
 rename-desktop-file: soundconverter.desktop


### PR DESCRIPTION
3.38 is EOL, see #2.

Fixes #2